### PR TITLE
Add Raycast script to copy current Notion page as markdown link

### DIFF
--- a/apps/raycast/scripts/notion-markdown-link.sh
+++ b/apps/raycast/scripts/notion-markdown-link.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# @raycast.schemaVersion 1
+# @raycast.title Notion: Copy Markdown Link
+# @raycast.mode silent
+# @raycast.packageName Notion
+# @raycast.description Copy the current Notion page as a markdown link
+
+if ! pgrep -x "Notion" > /dev/null; then
+    echo "Notion is not running"
+    exit 1
+fi
+
+PAGE_TITLE=$(osascript -e 'tell application "Notion" to get name of front window')
+PAGE_TITLE="${PAGE_TITLE% - Notion}"
+
+osascript -e 'tell application "Notion" to activate'
+sleep 0.1
+
+osascript -e '
+tell application "System Events"
+    tell process "Notion"
+        keystroke "l" using {command down}
+    end tell
+end tell'
+
+sleep 0.3
+
+URL=$(pbpaste)
+
+if [[ "$URL" != *"notion.so"* ]]; then
+    echo "Could not get Notion URL — try again"
+    exit 1
+fi
+
+URL="${URL%%\?*}"
+
+printf '%s' "[${PAGE_TITLE}](${URL})" | pbcopy
+
+echo "Copied: $PAGE_TITLE"

--- a/meta/configs/raycast.yaml
+++ b/meta/configs/raycast.yaml
@@ -1,0 +1,2 @@
+- link:
+    $HOME/raycast-scripts: apps/raycast/scripts

--- a/meta/profiles/mac
+++ b/meta/profiles/mac
@@ -7,3 +7,4 @@ nvim
 iterm
 pip
 fonts
+raycast


### PR DESCRIPTION
Adds a Raycast Script Command that grabs the current Notion page title and URL (via Cmd+L), strips query params, and writes [title](url) to the clipboard. Includes dotbot config to symlink scripts dir to ~/raycast-scripts and adds raycast to the mac install profile.